### PR TITLE
[feat] 新增 transaction proof 相关的 RPC API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Home page: [Home page](https://starcoinorg.github.io/starcoin-java/)
 
 ### 引入依赖
 
-** Maven **
+**Maven**
 
 ```xml
 
@@ -24,25 +24,25 @@ Home page: [Home page](https://starcoinorg.github.io/starcoin-java/)
 </dependency>
 ```
 
-** Gradle **
+**Gradle**
 
 ``` 
 implementation group: 'org.starcoin', name: 'sdk', version: '1.1.18'
 ```
 
-** Gradle short **
+**Gradle short**
 
 ``` 
 implementation 'org.starcoin:sdk:1.1.18'
 ```
 
-** Gradle kotlin **
+**Gradle kotlin**
 
 ``` 
 implementation("org.starcoin:sdk:1.1.18")
 ```
 
-** SBT **
+**SBT**
 
 ``` 
 libraryDependencies += "org.starcoin" % "sdk" % "1.1.18"

--- a/src/main/java/org/starcoin/api/BlockRPCClient.java
+++ b/src/main/java/org/starcoin/api/BlockRPCClient.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.starcoin.bean.Block;
 import org.starcoin.bean.BlockHeader;
+import org.starcoin.bean.BlockInfo;
 import org.starcoin.jsonrpc.client.JSONRPC2Session;
 import org.starcoin.jsonrpc.client.JSONRPC2SessionException;
 
@@ -65,6 +66,17 @@ public class BlockRPCClient {
     public Block getBlockByHeight(long height) throws JSONRPC2SessionException {
         JsonRPCClient<Block> client = new JsonRPCClient<>();
         return client.getObject(session, "chain.get_block_by_number", Collections.singletonList(height), 0, Block.class);
+    }
+
+    /**
+     * 通过block 高度 获取block和transaction的accumulator info
+     * @param height
+     * @return
+     * @throws JSONRPC2SessionException
+     */
+    public BlockInfo getBlockInfoByHeight(long height) throws JSONRPC2SessionException {
+        JsonRPCClient<BlockInfo> client = new JsonRPCClient<>();
+        return client.getObject(session, "chain.get_block_info_by_number", Collections.singletonList(height), 0, BlockInfo.class);
     }
 
     /**

--- a/src/main/java/org/starcoin/api/TransactionRPCClient.java
+++ b/src/main/java/org/starcoin/api/TransactionRPCClient.java
@@ -113,4 +113,70 @@ public class TransactionRPCClient {
         return client.getObjectArray(session, "chain.get_events", parameter, 0, Event.class);
     }
 
+    /**
+     * 通过 block hash 和 transaction index 获取某个 TransactionInfo
+     * @param blockHash
+     * @param transactionIndex
+     * @return
+     * @throws JSONRPC2SessionException
+     */
+    public Transaction getTransactionInfoByBlockAndIndex(String blockHash,int transactionIndex) throws JSONRPC2SessionException {
+        JsonRPCClient<Transaction> client = new JsonRPCClient<>();
+        List<Object> parameter = new ArrayList<>();
+        parameter.add(blockHash);
+        parameter.add(transactionIndex);
+        return client.getObject(session, "chain.get_txn_info_by_block_and_index", parameter, 0, Transaction.class);
+    }
+
+    /**
+     * 获取block和transaction证明的相关信息
+     * @param blockHash
+     * @param transactionGlobalIndex
+     * @return
+     * @throws JSONRPC2SessionException
+     */
+    public TransactionInfoWithProof getTransactionProof(String blockHash,long transactionGlobalIndex) throws JSONRPC2SessionException {
+        JsonRPCClient<TransactionInfoWithProof> client = new JsonRPCClient<>();
+        List<Object> parameter = new ArrayList<>();
+        parameter.add(blockHash);
+        parameter.add(transactionGlobalIndex);
+        return client.getObject(session, "chain.get_transaction_proof", parameter, 0, TransactionInfoWithProof.class);
+    }
+
+    /**
+     * 获取block和transaction证明的相关信息
+     * @param blockHash
+     * @param transactionGlobalIndex
+     * @param eventIndex
+     * @return
+     * @throws JSONRPC2SessionException
+     */
+    public TransactionInfoWithProof getTransactionProof(String blockHash,long transactionGlobalIndex,int eventIndex) throws JSONRPC2SessionException {
+        JsonRPCClient<TransactionInfoWithProof> client = new JsonRPCClient<>();
+        List<Object> parameter = new ArrayList<>();
+        parameter.add(blockHash);
+        parameter.add(transactionGlobalIndex);
+        parameter.add(eventIndex);
+        return client.getObject(session, "chain.get_transaction_proof", parameter, 0, TransactionInfoWithProof.class);
+    }
+
+    /**
+     * 获取block和transaction证明的相关信息
+     * @param blockHash
+     * @param transactionGlobalIndex
+     * @param eventIndex
+     * @param accessPath
+     * @return
+     * @throws JSONRPC2SessionException
+     */
+    public TransactionInfoWithProof getTransactionProof(String blockHash,long transactionGlobalIndex,int eventIndex,String accessPath) throws JSONRPC2SessionException {
+        JsonRPCClient<TransactionInfoWithProof> client = new JsonRPCClient<>();
+        List<Object> parameter = new ArrayList<>();
+        parameter.add(blockHash);
+        parameter.add(transactionGlobalIndex);
+        parameter.add(eventIndex);
+        parameter.add(accessPath);
+        return client.getObject(session, "chain.get_transaction_proof", parameter, 0, TransactionInfoWithProof.class);
+    }
+
 }

--- a/src/main/java/org/starcoin/bean/AccountProof.java
+++ b/src/main/java/org/starcoin/bean/AccountProof.java
@@ -1,0 +1,21 @@
+package org.starcoin.bean;
+
+import com.alibaba.fastjson.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class AccountProof extends BaseProof {
+
+    @JSONField(name = "leaf")
+    @JsonProperty("leaf")
+    private List<String> leaf;
+
+    public List<String> getLeaf() {
+        return leaf;
+    }
+
+    public void setLeaf(List<String> leaf) {
+        this.leaf = leaf;
+    }
+}

--- a/src/main/java/org/starcoin/bean/AccumulatorNode.java
+++ b/src/main/java/org/starcoin/bean/AccumulatorNode.java
@@ -1,0 +1,67 @@
+package org.starcoin.bean;
+
+import com.alibaba.fastjson.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class AccumulatorNode {
+
+    @JSONField(name = "accumulator_root")
+    @JsonProperty("accumulator_root")
+    private String accumulatorRoot;
+
+    @JSONField(name = "frozen_subtree_roots")
+    @JsonProperty("frozen_subtree_roots")
+    private List<String> frozenSubtreeRoots;
+
+    @JSONField(name = "num_leaves")
+    @JsonProperty("num_leaves")
+    private String numLeaves;
+
+    @JSONField(name = "num_nodes")
+    @JsonProperty("num_nodes")
+    private String numNodes;
+
+    public String getAccumulatorRoot() {
+        return accumulatorRoot;
+    }
+
+    public void setAccumulatorRoot(String accumulatorRoot) {
+        this.accumulatorRoot = accumulatorRoot;
+    }
+
+    public List<String> getFrozenSubtreeRoots() {
+        return frozenSubtreeRoots;
+    }
+
+    public void setFrozenSubtreeRoots(List<String> frozenSubtreeRoots) {
+        this.frozenSubtreeRoots = frozenSubtreeRoots;
+    }
+
+    public String getNumLeaves() {
+        return numLeaves;
+    }
+
+    public void setNumLeaves(String numLeaves) {
+        this.numLeaves = numLeaves;
+    }
+
+    public String getNumNodes() {
+        return numNodes;
+    }
+
+    public void setNumNodes(String numNodes) {
+        this.numNodes = numNodes;
+    }
+
+    @Override
+    public String toString() {
+        return "AccumulatorInfo{" +
+                "accumulatorRoot='" + accumulatorRoot + '\'' +
+                ", frozenSubtreeRoots=" + frozenSubtreeRoots +
+                ", numLeaves='" + numLeaves + '\'' +
+                ", numNodes='" + numNodes + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/org/starcoin/bean/BaseProof.java
+++ b/src/main/java/org/starcoin/bean/BaseProof.java
@@ -1,0 +1,28 @@
+package org.starcoin.bean;
+
+import com.alibaba.fastjson.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class BaseProof {
+
+    @JSONField(name = "siblings")
+    @JsonProperty("siblings")
+    public List<String> siblings;
+
+    public List<String> getSiblings() {
+        return siblings;
+    }
+
+    public void setSiblings(List<String> siblings) {
+        this.siblings = siblings;
+    }
+
+    @Override
+    public String toString() {
+        return "Proof{" +
+                "siblings=" + siblings +
+                '}';
+    }
+}

--- a/src/main/java/org/starcoin/bean/BlockInfo.java
+++ b/src/main/java/org/starcoin/bean/BlockInfo.java
@@ -1,0 +1,65 @@
+package org.starcoin.bean;
+
+import com.alibaba.fastjson.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class BlockInfo {
+
+    @JSONField(name = "block_accumulator_info")
+    @JsonProperty("block_accumulator_info")
+    private AccumulatorNode blockAccumulatorInfo;
+
+    @JSONField(name = "block_hash")
+    @JsonProperty("block_hash")
+    private String blockHash;
+
+    @JSONField(name = "total_difficulty")
+    @JsonProperty("total_difficulty")
+    private String totalDifficulty;
+
+    @JSONField(name = "txn_accumulator_info")
+    @JsonProperty("txn_accumulator_info")
+    private AccumulatorNode txnAccumulatorInfo;
+
+    public AccumulatorNode getBlockAccumulatorInfo() {
+        return blockAccumulatorInfo;
+    }
+
+    public void setBlockAccumulatorInfo(AccumulatorNode blockAccumulatorInfo) {
+        this.blockAccumulatorInfo = blockAccumulatorInfo;
+    }
+
+    public String getBlockHash() {
+        return blockHash;
+    }
+
+    public void setBlockHash(String blockHash) {
+        this.blockHash = blockHash;
+    }
+
+    public String getTotalDifficulty() {
+        return totalDifficulty;
+    }
+
+    public void setTotalDifficulty(String totalDifficulty) {
+        this.totalDifficulty = totalDifficulty;
+    }
+
+    public AccumulatorNode getTxnAccumulatorInfo() {
+        return txnAccumulatorInfo;
+    }
+
+    public void setTxnAccumulatorInfo(AccumulatorNode txnAccumulatorInfo) {
+        this.txnAccumulatorInfo = txnAccumulatorInfo;
+    }
+
+    @Override
+    public String toString() {
+        return "BlockNodeInfo{" +
+                "blockAccumulatorInfo=" + blockAccumulatorInfo +
+                ", blockHash='" + blockHash + '\'' +
+                ", totalDifficulty='" + totalDifficulty + '\'' +
+                ", txnAccumulatorInfo=" + txnAccumulatorInfo +
+                '}';
+    }
+}

--- a/src/main/java/org/starcoin/bean/EventProof.java
+++ b/src/main/java/org/starcoin/bean/EventProof.java
@@ -1,0 +1,39 @@
+package org.starcoin.bean;
+
+import com.alibaba.fastjson.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class EventProof {
+
+    @JSONField(name = "event")
+    @JsonProperty("event")
+    private String event;
+
+    @JSONField(name = "proof")
+    @JsonProperty("proof")
+    private BaseProof proof;
+
+    public String getEvent() {
+        return event;
+    }
+
+    public void setEvent(String event) {
+        this.event = event;
+    }
+
+    public BaseProof getProof() {
+        return proof;
+    }
+
+    public void setProof(BaseProof proof) {
+        this.proof = proof;
+    }
+
+    @Override
+    public String toString() {
+        return "EventProof{" +
+                "event='" + event + '\'' +
+                ", proof=" + proof +
+                '}';
+    }
+}

--- a/src/main/java/org/starcoin/bean/StateProof.java
+++ b/src/main/java/org/starcoin/bean/StateProof.java
@@ -1,0 +1,64 @@
+package org.starcoin.bean;
+
+import com.alibaba.fastjson.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class StateProof {
+
+    @JSONField(name = "account_proof")
+    @JsonProperty("account_proof")
+    private AccountProof accountProof;
+
+    @JSONField(name = "account_state")
+    @JsonProperty("account_state")
+    private String accountState;
+
+    @JSONField(name = "account_state_proof")
+    @JsonProperty("account_state_proof")
+    private AccountProof accountStateProof;
+
+    private String state;
+
+    public AccountProof getAccountProof() {
+        return accountProof;
+    }
+
+    public void setAccountProof(AccountProof accountProof) {
+        this.accountProof = accountProof;
+    }
+
+    public String getAccountState() {
+        return accountState;
+    }
+
+    public void setAccountState(String accountState) {
+        this.accountState = accountState;
+    }
+
+    public AccountProof getAccountStateProof() {
+        return accountStateProof;
+    }
+
+    public void setAccountStateProof(AccountProof accountStateProof) {
+        this.accountStateProof = accountStateProof;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    @Override
+    public String toString() {
+        return "StateProof{" +
+                "accountProof=" + accountProof +
+                ", accountState='" + accountState + '\'' +
+                ", accountStateProof=" + accountStateProof +
+                ", state='" + state + '\'' +
+                '}';
+    }
+
+}

--- a/src/main/java/org/starcoin/bean/TransactionInfo.java
+++ b/src/main/java/org/starcoin/bean/TransactionInfo.java
@@ -1,0 +1,130 @@
+package org.starcoin.bean;
+
+import com.alibaba.fastjson.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class TransactionInfo {
+
+    @JSONField(name = "block_hash")
+    @JsonProperty("block_hash")
+    private String blockHash;
+
+    @JSONField(name = "block_number")
+    @JsonProperty("block_number")
+    private String blockNumber;
+
+    @JSONField(name = "transaction_hash")
+    @JsonProperty("transaction_hash")
+    private String transactionHash;
+
+    @JSONField(name = "transaction_index")
+    @JsonProperty("transaction_index")
+    private int transactionIndex;
+
+    @JSONField(name = "transaction_global_index")
+    @JsonProperty("transaction_global_index")
+    private long transactionGlobalIndex;
+
+    @JSONField(name = "state_root_hash")
+    @JsonProperty("state_root_hash")
+    private String stateRootHash;
+
+    @JSONField(name = "event_root_hash")
+    @JsonProperty("event_root_hash")
+    private String eventRootHash;
+
+    @JSONField(name = "gas_used")
+    @JsonProperty("gas_used")
+    private String gasUsed;
+
+    @JSONField(name = "status")
+    @JsonProperty("status")
+    private String status;
+
+    public String getBlockHash() {
+        return blockHash;
+    }
+
+    public void setBlockHash(String blockHash) {
+        this.blockHash = blockHash;
+    }
+
+    public String getBlockNumber() {
+        return blockNumber;
+    }
+
+    public void setBlockNumber(String blockNumber) {
+        this.blockNumber = blockNumber;
+    }
+
+    public String getTransactionHash() {
+        return transactionHash;
+    }
+
+    public void setTransactionHash(String transactionHash) {
+        this.transactionHash = transactionHash;
+    }
+
+    public int getTransactionIndex() {
+        return transactionIndex;
+    }
+
+    public void setTransactionIndex(int transactionIndex) {
+        this.transactionIndex = transactionIndex;
+    }
+
+    public long getTransactionGlobalIndex() {
+        return transactionGlobalIndex;
+    }
+
+    public void setTransactionGlobalIndex(long transactionGlobalIndex) {
+        this.transactionGlobalIndex = transactionGlobalIndex;
+    }
+
+    public String getStateRootHash() {
+        return stateRootHash;
+    }
+
+    public void setStateRootHash(String stateRootHash) {
+        this.stateRootHash = stateRootHash;
+    }
+
+    public String getEventRootHash() {
+        return eventRootHash;
+    }
+
+    public void setEventRootHash(String eventRootHash) {
+        this.eventRootHash = eventRootHash;
+    }
+
+    public String getGasUsed() {
+        return gasUsed;
+    }
+
+    public void setGasUsed(String gasUsed) {
+        this.gasUsed = gasUsed;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    @Override
+    public String toString() {
+        return "TransactionInfo{" +
+                "blockHash='" + blockHash + '\'' +
+                ", blockNumber='" + blockNumber + '\'' +
+                ", transactionHash='" + transactionHash + '\'' +
+                ", transactionIndex=" + transactionIndex +
+                ", transactionGlobalIndex=" + transactionGlobalIndex +
+                ", stateRootHash='" + stateRootHash + '\'' +
+                ", eventRootHash='" + eventRootHash + '\'' +
+                ", gasUsed='" + gasUsed + '\'' +
+                ", status='" + status + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/org/starcoin/bean/TransactionInfoWithProof.java
+++ b/src/main/java/org/starcoin/bean/TransactionInfoWithProof.java
@@ -1,0 +1,65 @@
+package org.starcoin.bean;
+
+import com.alibaba.fastjson.annotation.JSONField;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class TransactionInfoWithProof {
+
+    @JSONField(name = "transaction_info")
+    @JsonProperty("transaction_info")
+    private TransactionInfo transactionInfo;
+
+    @JSONField(name = "proof")
+    @JsonProperty("proof")
+    private BaseProof proof;
+
+    @JSONField(name = "event_proof")
+    @JsonProperty("event_proof")
+    private EventProof eventProof;
+
+    @JSONField(name = "state_proof")
+    @JsonProperty("state_proof")
+    private StateProof stateProof;
+
+    public TransactionInfo getTransactionInfo() {
+        return transactionInfo;
+    }
+
+    public void setTransactionInfo(TransactionInfo transactionInfo) {
+        this.transactionInfo = transactionInfo;
+    }
+
+    public BaseProof getProof() {
+        return proof;
+    }
+
+    public void setProof(BaseProof proof) {
+        this.proof = proof;
+    }
+
+    public EventProof getEventProof() {
+        return eventProof;
+    }
+
+    public void setEventProof(EventProof eventProof) {
+        this.eventProof = eventProof;
+    }
+
+    public StateProof getStateProof() {
+        return stateProof;
+    }
+
+    public void setStateProof(StateProof stateProof) {
+        this.stateProof = stateProof;
+    }
+
+    @Override
+    public String toString() {
+        return "TransactionInfoWithProof{" +
+                "transactionInfo=" + transactionInfo +
+                ", proof=" + proof +
+                ", eventProof=" + eventProof +
+                ", stateProof=" + stateProof +
+                '}';
+    }
+}

--- a/src/test/java/org/starcoin/api/BlockRPCClientTest.java
+++ b/src/test/java/org/starcoin/api/BlockRPCClientTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import junit.framework.TestCase;
 import org.starcoin.bean.Block;
 import org.starcoin.bean.BlockHeader;
+import org.starcoin.bean.BlockInfo;
 import org.starcoin.jsonrpc.client.JSONRPC2SessionException;
 
 import java.net.URL;
@@ -26,7 +27,7 @@ public class BlockRPCClientTest extends TestCase {
         }
     }
 
-    public void testGetBlockByHeight() throws JsonProcessingException {
+    public void testGetBlockByHeight() {
         try {
             Block block = client.getBlockByHeight(5495169L);
             System.out.println(block);
@@ -39,6 +40,15 @@ public class BlockRPCClientTest extends TestCase {
         try {
             Block block = client.getBlockByHash("0xda40a21da882d2c7c0e011d20ff375f31914fd40fad4dd70b12df0ca3733c897");
             System.out.println(block);
+        } catch (JSONRPC2SessionException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void testGetBlockInfoByHeight() {
+        try {
+            BlockInfo blockInfo = client.getBlockInfoByHeight(8402745);
+            System.out.println(blockInfo);
         } catch (JSONRPC2SessionException e) {
             e.printStackTrace();
         }

--- a/src/test/java/org/starcoin/api/TransactionRPCClientTest.java
+++ b/src/test/java/org/starcoin/api/TransactionRPCClientTest.java
@@ -18,6 +18,7 @@ package org.starcoin.api;
 import junit.framework.TestCase;
 import org.starcoin.bean.Event;
 import org.starcoin.bean.Transaction;
+import org.starcoin.bean.TransactionInfoWithProof;
 import org.starcoin.jsonrpc.client.JSONRPC2SessionException;
 
 import java.net.URL;
@@ -60,4 +61,36 @@ public class TransactionRPCClientTest extends TestCase {
         }
 
     }
+
+    public void testGetTransactionInfoByBlockAndIndex() {
+        try {
+            Transaction transaction = client.getTransactionInfoByBlockAndIndex("0x49622a10f52d88909c09510898c4bc15ebc338d56c22f2a197d76fa8b627b35c",1);
+            System.out.println(transaction);
+        } catch (JSONRPC2SessionException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * 测试 getTransactionProof 的三个重载函数
+     */
+    public void testGetTransactionProof(){
+        String blockHash = "0x49622a10f52d88909c09510898c4bc15ebc338d56c22f2a197d76fa8b627b35c";
+        long transactionGlobalIndex = 10502811;
+        int eventIndex = 1;
+        String accessPath = "0x00000000000000000000000000000001/1/0x00000000000000000000000000000001::Account::WithdrawEvent";
+        try {
+            TransactionInfoWithProof transactionInfoWithProof = client.getTransactionProof(blockHash,transactionGlobalIndex);
+            System.out.println(transactionInfoWithProof);
+
+            TransactionInfoWithProof transactionInfoWithProof2 = client.getTransactionProof(blockHash,transactionGlobalIndex,eventIndex);
+            System.out.println(transactionInfoWithProof2);
+
+            TransactionInfoWithProof transactionInfoWithProof3 = client.getTransactionProof(blockHash,transactionGlobalIndex,eventIndex,accessPath);
+            System.out.println(transactionInfoWithProof3);
+        } catch (JSONRPC2SessionException e) {
+            e.printStackTrace();
+        }
+    }
+
 }


### PR DESCRIPTION
**RPC API**：
1. **chain.get_transaction_proof**
2. **chain.get_block_info_by_number**
3.  **chain.get_txn_info_by_block_and_index**


`chain.get_transaction_proof` 和 `chain.get_block_info_by_number` 用于 Transaction Proof 的。

```
curl --location --request POST 'https://barnard-seed.starcoin.org' \
--header 'Content-Type: application/json' \
--data-raw '{
 "id":101, 
 "jsonrpc":"2.0", 
 "method":"chain.get_transaction_proof", 
 "params":["0x49622a10f52d88909c09510898c4bc15ebc338d56c22f2a197d76fa8b627b35c",10502811,1,"0x00000000000000000000000000000001/1/0x00000000000000000000000000000001::Account::WithdrawEvent"]
}'
```
四个参数：
blockHash（必填）
transactionGlobalIndex（必填）
eventIndex（选填）
accessPath（选填）

> accessPath 注意格式有效性

**get_transaction_proof** 新增三个重载函数。

其他用法见 `BlockRPCClientTest.testGetTransactionProof()`
